### PR TITLE
chore: pin r-lib/actions to SHA refs

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -31,11 +31,11 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
-      - uses: r-lib/actions/setup-r@master
+      - uses: r-lib/actions/setup-r@6f6e5bc62fba3a704f74e7ad7ef7676c5c6a2590 # v2
         with:
           r-version: ${{ matrix.config.r }}
 
-      - uses: r-lib/actions/setup-pandoc@master
+      - uses: r-lib/actions/setup-pandoc@6f6e5bc62fba3a704f74e7ad7ef7676c5c6a2590 # v2
 
       - name: Query dependencies
         run: |


### PR DESCRIPTION
## Summary

Pin `r-lib/actions/setup-r` and `r-lib/actions/setup-pandoc` from `@master` to the v2 commit SHA (`6f6e5bc62fba3a704f74e7ad7ef7676c5c6a2590`). Same pattern as the earlier `bigrquery` and `ferret.meter.data` SHA-pin PRs.

## Testing

Functionally equivalent — r-lib/actions v2 is the current stable release.

Found via the nightly [`Audit GH Actions`](https://github.com/Utiligize/infrastructure/actions/workflows/audit-gh-actions.yml) workflow in Utiligize/infrastructure.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated and pinned GitHub Actions versions for R toolchain and Pandoc setup to specific commit hashes for improved build stability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->